### PR TITLE
upper limit on matplotlib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ emcee ~= 2.1
 nestle == 0.2.0
 corner ~= 1.0.2
 pandas ~= 0.18
-matplotlib >= 2.2
+matplotlib>=2.2,<=3.3
 psutil
 pyprind ~= 2.11
 munch


### PR DESCRIPTION
prevents matplotlib dependency on Python 3.7